### PR TITLE
Add JS variant of rule GCI505 - Idleness: Keep Screen On (addFlags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#333](https://github.com/green-code-initiative/creedengo-rules-specifications/pull/333) Add JS variant of rule GCI505 - Idleness: Keep Screen On (addFlags)
+
 ### Changed
 
 ### Deleted

--- a/src/main/rules/GCI505/javascript/GCI505.asciidoc
+++ b/src/main/rules/GCI505/javascript/GCI505.asciidoc
@@ -1,0 +1,26 @@
+:!sectids:
+
+== Why is this an issue?
+
+To avoid draining the battery, an Android device that is left idle quickly falls asleep.
+Hence, keeping the screen on should be avoided, unless it is absolutely necessary.
+
+== Example of non compliant code
+
+```js
+export default function KeepAwakeExample() {
+  useKeepAwake(); // Non compliant
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>This screen will never sleep!</Text>
+    </View>
+  );
+}
+```
+
+```js
+_activate = () => {
+    activateKeepAwake(); // Non-compliant
+    alert('Activated!');
+  };
+```

--- a/src/main/rules/GCI505/javascript/GCI505.json
+++ b/src/main/rules/GCI505/javascript/GCI505.json
@@ -1,0 +1,10 @@
+{
+  "tags": [
+    "idleness",
+    "environment",
+    "creedengo",
+    "react-native",
+    "eco-design"
+  ],
+  "compatibleLanguages": ["JAVASCRIPT", "TYPESCRIPT"]
+}


### PR DESCRIPTION
This pull request introduces a new JavaScript variant of the rule GCI505 - Idleness: Keep Screen On, and includes documentation and metadata updates to support this new rule.

### New Rule Addition:

* Added JS variant of rule GCI505 - Idleness: Keep Screen On to the changelog (`CHANGELOG.md`).
* Documented the issue and provided examples of non-compliant code in the new rule's documentation file (`src/main/rules/GCI505/javascript/GCI505.asciidoc`).

### Metadata Update:

* Added metadata for the new rule, including tags and compatible languages (`src/main/rules/GCI505/javascript/GCI505.json`).

-----

Work done by @glbrtrnh
Superseeds PR #333 